### PR TITLE
Allow recursive calls to in_database

### DIFF
--- a/dynamic_db_router/router.py
+++ b/dynamic_db_router/router.py
@@ -15,7 +15,6 @@ class DynamicDbRouter(object):
     def db_for_read(self, model, **hints):
         return getattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', ['default'])[-1]
 
-
     def db_for_write(self, model, **hints):
         return getattr(THREAD_LOCAL, 'DB_FOR_WRITE_OVERRIDE', ['default'])[-1]
 

--- a/dynamic_db_router/tests/tests.py
+++ b/dynamic_db_router/tests/tests.py
@@ -43,7 +43,6 @@ class TestInDataBaseContextManager(TestCase):
         self.assertEqual(test_count, 0)
         self.assertEqual(default_count, 0)
 
-
     def test_recursive_context_manager(self):
         with in_database('test', write=True):
             G(TestModel, name='Arnold')

--- a/dynamic_db_router/tests/tests.py
+++ b/dynamic_db_router/tests/tests.py
@@ -10,6 +10,8 @@ from .models import TestModel
 
 
 class TestInDataBaseContextManager(TestCase):
+    multi_db = True
+
     def test_string_identifier(self):
         G(TestModel, name='Arnold')
         with in_database('default'):
@@ -40,6 +42,15 @@ class TestInDataBaseContextManager(TestCase):
         default_count = TestModel.objects.count()
         self.assertEqual(test_count, 0)
         self.assertEqual(default_count, 0)
+
+
+    def test_recursive_context_manager(self):
+        with in_database('test', write=True):
+            G(TestModel, name='Arnold')
+            with in_database('default', write=True):
+                pass
+            test_count = TestModel.objects.count()
+        self.assertEqual(test_count, 1)
 
     def test_bad_input_value(self):
         with self.assertRaises(ValueError):


### PR DESCRIPTION
This allows to call recursively the context manager. Before this fix, the exit method would reset the database to default. Now a stack is used to know which database was the previous.

This is basically the same as merge request #3. I couldn't reopen the previous request because I made a force push. The code had a bug and I didn't have time to fix it until now.
