### PR TITLE
Add feature for nested usage of the context manager

### DIFF
--- a/dynamic_db_router/router.py
+++ b/dynamic_db_router/router.py
@@ -80,6 +80,7 @@ class in_database(object):
         with in_database(db_config):
             # Run queries
     """
+
     def __init__(self, database, read=True, write=False):
         self.read = read
         self.write = write
@@ -99,6 +100,8 @@ class in_database(object):
             raise ValueError(msg)
 
     def __enter__(self):
+        self.previous_read_db = getattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', 'default')
+        self.previous_write_db = getattr(THREAD_LOCAL, 'DB_FOR_WRITE_OVERRIDE', 'default')
         if self.read:
             setattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', self.database)
         if self.write:
@@ -106,8 +109,9 @@ class in_database(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        setattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', None)
-        setattr(THREAD_LOCAL, 'DB_FOR_WRITE_OVERRIDE', None)
+        setattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', self.previous_read_db)
+        setattr(THREAD_LOCAL, 'DB_FOR_WRITE_OVERRIDE', self.previous_write_db)
+
         if self.created_db_config:
             connections[self.unique_db_id].close()
             del connections.databases[self.unique_db_id]
@@ -119,3 +123,5 @@ class in_database(object):
             with self:
                 return querying_func(*args, **kwargs)
         return inner
+
+    

--- a/dynamic_db_router/router.py
+++ b/dynamic_db_router/router.py
@@ -123,4 +123,3 @@ class in_database(object):
             with self:
                 return querying_func(*args, **kwargs)
         return inner
-

--- a/dynamic_db_router/router.py
+++ b/dynamic_db_router/router.py
@@ -123,5 +123,3 @@ class in_database(object):
             with self:
                 return querying_func(*args, **kwargs)
         return inner
-
-    

--- a/dynamic_db_router/router.py
+++ b/dynamic_db_router/router.py
@@ -80,6 +80,7 @@ class in_database(object):
         with in_database(db_config):
             # Run queries
     """
+
     def __init__(self, database, read=True, write=False):
         self.read = read
         self.write = write
@@ -99,6 +100,8 @@ class in_database(object):
             raise ValueError(msg)
 
     def __enter__(self):
+        self.previous_read_db = getattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', 'default')
+        self.previous_write_db = getattr(THREAD_LOCAL, 'DB_FOR_WRITE_OVERRIDE', 'default')
         if self.read:
             setattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', self.database)
         if self.write:
@@ -106,8 +109,9 @@ class in_database(object):
         return self
 
     def __exit__(self, exc_type, exc_value, traceback):
-        setattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', None)
-        setattr(THREAD_LOCAL, 'DB_FOR_WRITE_OVERRIDE', None)
+        setattr(THREAD_LOCAL, 'DB_FOR_READ_OVERRIDE', self.previous_read_db)
+        setattr(THREAD_LOCAL, 'DB_FOR_WRITE_OVERRIDE', self.previous_write_db)
+
         if self.created_db_config:
             connections[self.unique_db_id].close()
             del connections.databases[self.unique_db_id]
@@ -119,3 +123,4 @@ class in_database(object):
             with self:
                 return querying_func(*args, **kwargs)
         return inner
+


### PR DESCRIPTION
Hi, 

When using your code I saw a behavior which was (for me) unexpected. I give an example on the following code (we suppose there are 3 databases, 'default', 'DataBase1' and 'DataBase2').

``` python
with in_database('DataBase1', write=True):
     # Do some stuff 
     with in_database('DataBase2', write=True): 
          # Do some stuff
```

When leaving the second context manager, the now routed database becomes the 'default' and not the 'DataBase1'. I just modified a few lines of code to ensure that the in_database object keeps track of the current routed db (current = when entering into the context manager) when routing to a new one. It allows in_database to route to this previous database when leaving the context manager. 
If this feature seems appropriate to you, would you like to integrate it on the source project so that my colleagues can directly download it ? 

I take this opportunity to thank you for your module, I find it elegant and useful. 

Sven 
