### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,7 +4,7 @@
 .. image:: https://coveralls.io/repos/ambitioninc/django-dynamic-db-router/badge.png?branch=develop
     :target: https://coveralls.io/r/ambitioninc/django-dynamic-db-router?branch=develop
 
-.. image:: https://pypip.in/v/django-dynamic-db-router/badge.png
+.. image:: https://img.shields.io/pypi/v/django-dynamic-db-router.svg
     :target: https://pypi.python.org/pypi/django-dynamic-db-router/
     :alt: Latest PyPI version
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20django-dynamic-db-router))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `django-dynamic-db-router`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.